### PR TITLE
Retry transient Grok authentication preflights

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pstack",
       "source": "./plugins/pstack",
       "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "Lauren Tan (original)"
       },

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 This port applies the Cursor → Claude Code substitutions in skill bodies. Earlier drafts left them flagged; this revision resolves them. A later pass added a Codex build that shares the same skills; see [Codex port](#codex-port) below.
 
-## Unreleased
+## 1.0.2 retries transient Grok authentication preflights
 
 `pstack-runner` now waits five seconds and retries `grok models` once when Grok's first preflight would be classified as unauthenticated. This handles the CLI's brief contradictory output during self-update, when it can print an unauthenticated banner while exiting 0 and listing the requested model. A second failure remains terminal with exit 77. The retry shares the existing absolute deadline and cancellation latch, the receipt keeps evidence from both attempts, and model execution still runs at most once.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 This port applies the Cursor → Claude Code substitutions in skill bodies. Earlier drafts left them flagged; this revision resolves them. A later pass added a Codex build that shares the same skills; see [Codex port](#codex-port) below.
 
+## Unreleased
+
+`pstack-runner` now waits five seconds and retries `grok models` once when Grok's first preflight would be classified as unauthenticated. This handles the CLI's brief contradictory output during self-update, when it can print an unauthenticated banner while exiting 0 and listing the requested model. A second failure remains terminal with exit 77. The retry shares the existing absolute deadline and cancellation latch, the receipt keeps evidence from both attempts, and model execution still runs at most once.
+
 ## 1.0.1 removes duplicate workflow entries
 
 Claude Code and Codex both load the native `plugins/pstack/skills/` tree. Codex 0.149.0 also converts each `plugins/pstack/commands/*.md` file into a generated `.codex-plugin/migrated-command-skills/source-command-*/SKILL.md`. The 31 same-named command trampolines therefore doubled Codex's workflow inventory. Claude's component inventory also registered both layers, although Claude Desktop visually merged the duplicate names.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This repository also keeps:
 
 ## Staying close to Lauren's pstack
 
-Open Pstack 1.0.1 tracks pstack 0.14.2 at Cursor commit [`46125561306434d8a1d7745d540d8932ab0cd2a2`](https://github.com/cursor/plugins/commit/46125561306434d8a1d7745d540d8932ab0cd2a2).
+Open Pstack 1.0.2 tracks pstack 0.14.2 at Cursor commit [`46125561306434d8a1d7745d540d8932ab0cd2a2`](https://github.com/cursor/plugins/commit/46125561306434d8a1d7745d540d8932ab0cd2a2).
 
 The two projects have separate version numbers. The pstack version identifies Lauren's upstream content. The Open Pstack version identifies the Claude Code and Codex package built from it.
 

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -10,9 +10,9 @@ open-pstack tracks [Cursor's pstack](https://github.com/cursor/plugins/tree/main
 | Path | `pstack/` |
 | Commit | `46125561306434d8a1d7745d540d8932ab0cd2a2` |
 | Upstream version | `0.14.2` |
-| open-pstack version | `1.0.1` |
+| open-pstack version | `1.0.2` |
 
-The same Cursor commit remains the sync point for open-pstack 1.0.1. `README-UPSTREAM.md` preserves its pstack README verbatim. `CHANGES.md` and `NOTICE.md` describe the adaptations and provenance.
+The same Cursor commit remains the sync point for open-pstack 1.0.2. `README-UPSTREAM.md` preserves its pstack README verbatim. `CHANGES.md` and `NOTICE.md` describe the adaptations and provenance.
 
 ## Check for changes
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2,7 +2,7 @@
 
 This page contains the full skill, dependency, runtime, and porting reference. For the plain-English introduction and quick start, see the [main README](../README.md).
 
-[Poteto](https://x.com/poteto)'s [pstack](https://github.com/cursor/plugins/tree/main/pstack), adapted to run in Claude Code and Codex without Cursor. One shared skill tree serves both harnesses; Grok remains available as a model-provider lane. Version 1.0.1 is synced to Cursor pstack v0.14.2 at `46125561306434d8a1d7745d540d8932ab0cd2a2`. See [UPSTREAM.md](../UPSTREAM.md) for the exact sync contract.
+[Poteto](https://x.com/poteto)'s [pstack](https://github.com/cursor/plugins/tree/main/pstack), adapted to run in Claude Code and Codex without Cursor. One shared skill tree serves both harnesses; Grok remains available as a model-provider lane. Version 1.0.2 is synced to Cursor pstack v0.14.2 at `46125561306434d8a1d7745d540d8932ab0cd2a2`. See [UPSTREAM.md](../UPSTREAM.md) for the exact sync contract.
 
 Original by Lauren Tan. This distribution builds on Michael Denyer's [pstack-claude](https://github.com/michael-denyer/pstack-claude) port and retains its history and MIT attribution. It imports seven MIT-licensed skills from [cursor-team-kit](https://github.com/cursor/plugins/tree/main/cursor-team-kit): `deslop`, `thermo-nuclear-code-quality-review`, `make-pr-easy-to-review`, `fix-ci`, `fix-merge-conflicts`, `get-pr-comments`, `what-did-i-get-done`.
 

--- a/plugins/pstack/.claude-plugin/plugin.json
+++ b/plugins/pstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pstack",
   "displayName": "pstack",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. Ported from cursor/plugins/pstack for Claude Code and Codex.",
   "author": {
     "name": "Lauren Tan"

--- a/plugins/pstack/.codex-plugin/plugin.json
+++ b/plugins/pstack/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pstack",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. Codex port of the Claude Code plugin; skills are shared, tool names resolve via skills/poteto-mode/references/codex-tools.md.",
   "author": {
     "name": "Lauren Tan"

--- a/plugins/pstack/skills/poteto-mode/references/provider-dispatch.md
+++ b/plugins/pstack/skills/poteto-mode/references/provider-dispatch.md
@@ -55,7 +55,9 @@ pstack-runner \
   [--timeout <seconds>]
 ```
 
-Pass arguments as an argv array or quote every path. Never interpolate prompt text into a shell command. The launcher preflights the assigned CLI and authentication, invokes exactly once, disables recursive agents and ambient skill dispatch where the CLI supports it, restricts the built-in tool surface, and records the exact provider/model/effort flags. External lanes do not receive the parent's MCP surface. Keep MCP-dependent Why and Reflect roles on `inherit-parent` or `auto`. The launcher never falls back.
+Pass arguments as an argv array or quote every path. Never interpolate prompt text into a shell command. The launcher preflights the assigned CLI and authentication, invokes the model exactly once, disables recursive agents and ambient skill dispatch where the CLI supports it, restricts the built-in tool surface, and records the exact provider/model/effort flags. External lanes do not receive the parent's MCP surface. Keep MCP-dependent Why and Reflect roles on `inherit-parent` or `auto`. The launcher never falls back.
+
+Grok authentication preflight has one bounded retry. If the first `grok models` result would be classified as unauthenticated, the runner waits five seconds and tries the same preflight once more. A second failure is terminal. The delay and second attempt share the runner's absolute deadline and cancellation latch, and the receipt keeps evidence from both attempts. Model execution is never retried.
 
 The parent tool sandbox still governs whether a subscribed child CLI can reach its credentials and network. Run setup's live probe from the actual parent profile. A blocked external CLI is a loud dropout, not a reason to elevate permissions or substitute a model silently.
 

--- a/plugins/pstack/skills/poteto-mode/scripts/runner/run.test.ts
+++ b/plugins/pstack/skills/poteto-mode/scripts/runner/run.test.ts
@@ -21,7 +21,7 @@ let bin = "";
 let previousPath: string | undefined;
 
 const fake = `#!/usr/bin/env bun
-import { unlinkSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, unlinkSync, writeFileSync } from "node:fs";
 const args = process.argv.slice(2);
 const name = process.argv[1].split("/").at(-1);
 const isPreflight =
@@ -66,6 +66,20 @@ if (name === "codex" && args[0] === "login") {
   process.exit(0);
 }
 if (name === "grok" && args[0] === "models") {
+  if (process.env.FAKE_GROK_PREFLIGHT_LOG_PATH) {
+    appendFileSync(process.env.FAKE_GROK_PREFLIGHT_LOG_PATH, "attempt\\n");
+  }
+  const transientMarker = process.env.FAKE_GROK_TRANSIENT_UNAUTH_PATH;
+  if (transientMarker && !existsSync(transientMarker)) {
+    writeFileSync(transientMarker, String(process.pid));
+    console.log("Available models:\\n  * grok-4.6 (default)");
+    console.error("You are not authenticated.");
+    process.exit(0);
+  }
+  if (process.env.FAKE_GROK_MISSING_MODEL === "1") {
+    console.log("You are logged in with grok.com.\\nAvailable models:\\n  * grok-4.5 (default)");
+    process.exit(0);
+  }
   if (process.env.FAKE_GROK_UNAUTH === "1") {
     console.error("Not logged in. Run grok auth login.");
     process.exit(1);
@@ -219,6 +233,9 @@ beforeEach(() => {
   delete process.env.FAKE_MODEL_EXITING_PATH;
   delete process.env.FAKE_REMOVE_EXECUTABLE_AFTER_PREFLIGHT;
   delete process.env.FAKE_GROK_UNAUTH;
+  delete process.env.FAKE_GROK_TRANSIENT_UNAUTH_PATH;
+  delete process.env.FAKE_GROK_PREFLIGHT_LOG_PATH;
+  delete process.env.FAKE_GROK_MISSING_MODEL;
   delete process.env.FAKE_DESCENDANT_HOLDS_PIPES_MS;
   delete process.env.FAKE_DESCENDANT_PID_PATH;
   delete process.env.FAKE_SELF_SIGNAL;
@@ -240,6 +257,9 @@ afterEach(() => {
   delete process.env.FAKE_MODEL_EXITING_PATH;
   delete process.env.FAKE_REMOVE_EXECUTABLE_AFTER_PREFLIGHT;
   delete process.env.FAKE_GROK_UNAUTH;
+  delete process.env.FAKE_GROK_TRANSIENT_UNAUTH_PATH;
+  delete process.env.FAKE_GROK_PREFLIGHT_LOG_PATH;
+  delete process.env.FAKE_GROK_MISSING_MODEL;
   delete process.env.FAKE_DESCENDANT_HOLDS_PIPES_MS;
   delete process.env.FAKE_DESCENDANT_PID_PATH;
   delete process.env.FAKE_SELF_SIGNAL;
@@ -294,17 +314,124 @@ describe("runLane", () => {
     });
   });
 
-  it("classifies Grok authentication failure before model availability", async () => {
+  it("retries a contradictory Grok authentication preflight before running the model", async () => {
+    const transientMarker = join(scratch, "grok-transient-unauth.seen");
+    const preflightLog = join(scratch, "grok-transient-unauth.log");
+    process.env.FAKE_GROK_TRANSIENT_UNAUTH_PATH = transientMarker;
+    process.env.FAKE_GROK_PREFLIGHT_LOG_PATH = preflightLog;
+    const modelStarted = join(scratch, "grok-transient-model.started");
+    process.env.FAKE_MODEL_STARTED_PATH = modelStarted;
+    const input = options("grok", "grok-transient-unauth");
+    const result = await runLane(input);
+
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(preflightLog, "utf8")).toBe("attempt\nattempt\n");
+    expect(existsSync(modelStarted)).toBe(true);
+    expect(receipt(input.receiptPath)).toMatchObject({
+      status: "complete",
+      preflight: { status: "passed" },
+    });
+    expect(receipt(input.receiptPath).preflight.evidence).toContain(
+      "You are not authenticated."
+    );
+    expect(receipt(input.receiptPath).preflight.evidence).toContain(
+      "attempt 2 passed"
+    );
+  }, 10_000);
+
+  it("classifies Grok authentication failure after two consecutive preflights", async () => {
     process.env.FAKE_GROK_UNAUTH = "1";
+    const preflightLog = join(scratch, "grok-unauthenticated.log");
+    process.env.FAKE_GROK_PREFLIGHT_LOG_PATH = preflightLog;
     const modelStarted = join(scratch, "grok-model.started");
     process.env.FAKE_MODEL_STARTED_PATH = modelStarted;
     const input = options("grok", "grok-unauthenticated");
     const result = await runLane(input);
 
     expect(result.exitCode).toBe(77);
+    expect(readFileSync(preflightLog, "utf8")).toBe("attempt\nattempt\n");
     expect(existsSync(modelStarted)).toBe(false);
     expect(receipt(input.receiptPath)).toMatchObject({
       status: "unauthenticated",
+      preflight: { status: "failed" },
+    });
+    expect(receipt(input.receiptPath).preflight.evidence).toContain(
+      "attempt 2 failed"
+    );
+  }, 10_000);
+
+  it("counts the Grok retry delay against the wrapper deadline", async () => {
+    const transientMarker = join(scratch, "grok-deadline-unauth.seen");
+    const preflightLog = join(scratch, "grok-deadline-unauth.log");
+    process.env.FAKE_GROK_TRANSIENT_UNAUTH_PATH = transientMarker;
+    process.env.FAKE_GROK_PREFLIGHT_LOG_PATH = preflightLog;
+    const modelStarted = join(scratch, "grok-deadline-model.started");
+    process.env.FAKE_MODEL_STARTED_PATH = modelStarted;
+    const input = {
+      ...options("grok", "grok-preflight-retry-deadline"),
+      timeoutMs: 700,
+    };
+    const result = await runLane(input);
+    const recorded = receipt(input.receiptPath);
+
+    expect(result.exitCode).toBe(124);
+    expect(readFileSync(preflightLog, "utf8")).toBe("attempt\n");
+    expect(existsSync(modelStarted)).toBe(false);
+    expect(recorded).toMatchObject({
+      status: "timed-out",
+      preflight: { status: "timed-out" },
+    });
+    expect(recorded.preflight.evidence).toContain("You are not authenticated.");
+    expect(recorded.elapsedMs).toBeLessThan(1_200);
+  });
+
+  it("cancels during the Grok retry delay without starting another preflight", async () => {
+    const transientMarker = join(scratch, "grok-cancel-unauth.pid");
+    const preflightLog = join(scratch, "grok-cancel-unauth.log");
+    const input = options("grok", "grok-preflight-retry-cancelled");
+    const runner = Bun.spawn([process.execPath, ...runnerArgs(input)], {
+      cwd: scratch,
+      env: {
+        ...process.env,
+        FAKE_GROK_TRANSIENT_UNAUTH_PATH: transientMarker,
+        FAKE_GROK_PREFLIGHT_LOG_PATH: preflightLog,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = new Response(runner.stdout).text();
+    const stderr = new Response(runner.stderr).text();
+    await waitFor(transientMarker);
+    await waitForExit(Number(readFileSync(transientMarker, "utf8")));
+    await Bun.sleep(200);
+    runner.kill("SIGTERM");
+
+    expect(await exitWithin(runner, 2_000)).toBe(130);
+    await Promise.all([stdout, stderr]);
+    expect(readFileSync(preflightLog, "utf8")).toBe("attempt\n");
+    expect(receipt(input.receiptPath)).toMatchObject({
+      status: "cancelled",
+      preflight: { status: "cancelled" },
+      error: {
+        message: "launcher received SIGTERM during authentication preflight retry delay",
+      },
+    });
+  });
+
+  it("does not retry a Grok preflight with a missing model", async () => {
+    process.env.FAKE_GROK_MISSING_MODEL = "1";
+    const preflightLog = join(scratch, "grok-missing-model.log");
+    process.env.FAKE_GROK_PREFLIGHT_LOG_PATH = preflightLog;
+    const modelStarted = join(scratch, "grok-missing-model.started");
+    process.env.FAKE_MODEL_STARTED_PATH = modelStarted;
+    const input = options("grok", "grok-missing-model");
+    const result = await runLane(input);
+
+    expect(result.exitCode).toBe(69);
+    expect(readFileSync(preflightLog, "utf8")).toBe("attempt\n");
+    expect(existsSync(modelStarted)).toBe(false);
+    expect(receipt(input.receiptPath)).toMatchObject({
+      status: "unavailable-model",
       preflight: { status: "failed" },
     });
   });

--- a/plugins/pstack/skills/poteto-mode/scripts/runner/run.ts
+++ b/plugins/pstack/skills/poteto-mode/scripts/runner/run.ts
@@ -20,6 +20,7 @@ import type {
 import { UsageError } from "./types.ts";
 
 const ERROR_EVIDENCE_LIMIT = 4_000;
+const GROK_PREFLIGHT_RETRY_DELAY_MS = 5_000;
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 interface ProcessResult {
@@ -38,6 +39,8 @@ interface RunCancellation {
   readonly signal: CancellationSignal | null;
   dispose(): void;
 }
+
+type RetryWaitResult = "ready" | "cancelled" | "timed-out";
 
 export interface RunResult {
   readonly exitCode: number;
@@ -318,6 +321,34 @@ async function runProcess(
   }
 }
 
+async function waitForGrokPreflightRetry(
+  deadlineAt: number | null,
+  cancellation: RunCancellation
+): Promise<RetryWaitResult> {
+  if (cancellation.signal !== null) return "cancelled";
+
+  const now = Date.now();
+  if (deadlineAt !== null && now >= deadlineAt) return "timed-out";
+
+  const retryAt = now + GROK_PREFLIGHT_RETRY_DELAY_MS;
+  const wakeAt = deadlineAt === null ? retryAt : Math.min(retryAt, deadlineAt);
+  const timerResult: RetryWaitResult = wakeAt < retryAt ? "timed-out" : "ready";
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    const result = await Promise.race([
+      cancellation.promise.then((): RetryWaitResult => "cancelled"),
+      new Promise<RetryWaitResult>((resolve) => {
+        timer = setTimeout(() => resolve(timerResult), wakeAt - now);
+      }),
+    ]);
+    if (cancellation.signal !== null) return "cancelled";
+    if (deadlineAt !== null && Date.now() >= deadlineAt) return "timed-out";
+    return result;
+  } finally {
+    if (timer !== null) clearTimeout(timer);
+  }
+}
+
 function preflightPassed(provider: Provider, model: string, result: ProcessResult): boolean {
   if (result.exitCode !== 0 || result.timedOut) return false;
   const combined = `${result.stdout}\n${result.stderr}`;
@@ -355,6 +386,31 @@ function unavailableStatus(value: string): ReceiptStatus {
     return "unavailable-model";
   }
   return "child-failed";
+}
+
+function preflightFailureStatus(
+  provider: Provider,
+  model: string,
+  value: string
+): ReceiptStatus {
+  const status = unavailableStatus(value);
+  if (status !== "child-failed") return status;
+  return provider === "grok" && !value.includes(model)
+    ? "unavailable-model"
+    : "unauthenticated";
+}
+
+function retriedPreflightEvidence(
+  first: string,
+  second: string,
+  secondPassed: boolean
+): string {
+  const firstLabel = "attempt 1 failed:\n";
+  const secondLabel = `\n\nattempt 2 ${secondPassed ? "passed" : "failed"}:\n`;
+  const payloadLimit = ERROR_EVIDENCE_LIMIT - firstLabel.length - secondLabel.length;
+  const firstLimit = Math.floor(payloadLimit / 2);
+  const secondLimit = payloadLimit - firstLimit;
+  return `${firstLabel}${first.slice(0, firstLimit)}${secondLabel}${second.slice(0, secondLimit)}`;
 }
 
 function statusExitCode(status: ReceiptStatus): number {
@@ -553,7 +609,7 @@ async function executeLane(
   }
 
   const preflightExecutable = executable;
-  const preflightResult = await runProcess(
+  let preflightResult = await runProcess(
     preflightExecutable,
     preflight,
     options.cwd,
@@ -562,11 +618,61 @@ async function executeLane(
     deadlineAt,
     cancellation
   );
-  const rawPreflightEvidence = evidence(`${preflightResult.stdout}\n${preflightResult.stderr}`);
-  const passed = preflightPassed(options.provider, options.model, preflightResult);
-  const preflightEvidence = passed
+  let rawPreflightEvidence = evidence(`${preflightResult.stdout}\n${preflightResult.stderr}`);
+  let passed = preflightPassed(options.provider, options.model, preflightResult);
+  let preflightEvidence = passed
     ? successfulPreflightEvidence(options.provider, options.model)
     : rawPreflightEvidence;
+
+  if (
+    options.provider === "grok" &&
+    !passed &&
+    preflightResult.cancelledBy === null &&
+    !preflightResult.timedOut &&
+    preflightFailureStatus(options.provider, options.model, rawPreflightEvidence) ===
+      "unauthenticated"
+  ) {
+    preflightState = {
+      argv: [preflightExecutable, ...preflight.args],
+      status: "failed",
+      evidence: rawPreflightEvidence,
+    };
+    progress.preflight = preflightState;
+
+    const retryWait = await waitForGrokPreflightRetry(deadlineAt, cancellation);
+    if (retryWait !== "ready") {
+      preflightState = {
+        ...preflightState,
+        status: retryWait === "cancelled" ? "cancelled" : "timed-out",
+      };
+      progress.preflight = preflightState;
+      return finishWithoutChild(
+        retryWait === "cancelled" ? "cancelled" : "timed-out",
+        "during authentication preflight retry delay"
+      );
+    }
+
+    const firstPreflightEvidence = rawPreflightEvidence;
+    preflightResult = await runProcess(
+      preflightExecutable,
+      preflight,
+      options.cwd,
+      env,
+      "",
+      deadlineAt,
+      cancellation
+    );
+    rawPreflightEvidence = evidence(`${preflightResult.stdout}\n${preflightResult.stderr}`);
+    passed = preflightPassed(options.provider, options.model, preflightResult);
+    preflightEvidence = retriedPreflightEvidence(
+      firstPreflightEvidence,
+      passed
+        ? successfulPreflightEvidence(options.provider, options.model)
+        : rawPreflightEvidence,
+      passed
+    );
+  }
+
   preflightState = {
     argv: [preflightExecutable, ...preflight.args],
     status: preflightResult.cancelledBy !== null
@@ -582,16 +688,16 @@ async function executeLane(
 
   if (preflightState.status !== "passed") {
     const completed = Date.now();
-    const preflightFailure = unavailableStatus(preflightEvidence);
+    const preflightFailure = preflightFailureStatus(
+      options.provider,
+      options.model,
+      rawPreflightEvidence
+    );
     const status: ReceiptStatus = preflightResult.cancelledBy !== null
       ? "cancelled"
       : preflightResult.timedOut
         ? "timed-out"
-        : preflightFailure !== "child-failed"
-          ? preflightFailure
-          : options.provider === "grok" && !preflightEvidence.includes(options.model)
-            ? "unavailable-model"
-            : "unauthenticated";
+        : preflightFailure;
     receipt = completeReceipt(options, {
       status,
       startedAt,


### PR DESCRIPTION
Closes #11

## What changed

- retry a Grok preflight once after five seconds when the first result would be classified as unauthenticated
- retain both preflight attempts in receipt evidence
- keep the retry under the existing absolute deadline and cancellation latch
- leave missing-model failures and model execution single-shot
- bump Open Pstack from 1.0.1 to 1.0.2 across all package and documentation version surfaces

## Verification

- [x] Bun tests, strict typecheck, static invariants, and plugin validation pass.
- [x] The exact candidate is installed in every affected harness.
- [x] The changed behavior passes from each real user surface.
- [x] The installed version, action, and observed result appear below.

Live evidence:

- Candidate: `1b8a85f`
- Installed version: `pstack@open-pstack` 1.0.2, enabled in Claude Code and Codex
- Install parity: zero tracked-file mismatches between candidate `plugins/pstack` and both managed 1.0.2 caches
- Claude surface: a fresh `claude -p` process ran the installed Claude cache through the contradictory Grok fixture and returned exact marker `PSTACK_INSTALLED_CLAUDE_OK`
- Codex surface: a fresh `codex exec` process ran the installed Codex cache through the same fixture and returned exact marker `PSTACK_INSTALLED_CODEX_OK`
- Observed in both receipts: first preflight printed `You are not authenticated.` while exiting 0 and listing `grok-4.6`; the runner waited five seconds, passed the second preflight, invoked the model exactly once, verified provider model `grok-4.6-build`, and exited 0
- Evidence: `/Users/ericlitman/projects/pstack/evidence/issue-11-grok-preflight-retry/installed-1.0.2/{claude-parent,codex-parent}/receipt.json`
- Local gates: Bun 1.4.0, 93 tests / 343 assertions, strict typecheck, manifest parsing, static invariants, `git diff --check`, and `claude plugin validate plugins/pstack` all passed
