### PR TITLE
release: Open Pstack 1.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pstack",
       "source": "./plugins/pstack",
       "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "Lauren Tan (original)"
       },

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 This port applies the Cursor → Claude Code substitutions in skill bodies. Earlier drafts left them flagged; this revision resolves them. A later pass added a Codex build that shares the same skills; see [Codex port](#codex-port) below.
 
+## 1.2.0 adds verified multi-PR plans, earlier runtime diagnostics, and shared review-bot triage
+
+Plans with several stages now use one checklist instead of an overview and separate files for each stage. It has one ordered section for every pull request and keeps all ten ways of testing the real product, unit tests, live and performance proof, checks for how changes work together, merge rules, and supporting details in one place. A Node-based checker with no extra dependencies rejects missing or out-of-order sections, fake screenshots, empty definitions of success, incomplete performance proof, incorrectly written review checks, unsupported punctuation, and incorrect command use. Claude Code and Codex use the same installed skill and checker through their existing parent-controlled setup. If a provider fails, it is identified by name and treated as a dropout. No backup provider or hidden time limit was added.
+
+The shared startup script now checks for Node before using features that only Bun provides. If the startup script or watcher is run with Node, it prints one clear message and exits cleanly instead of failing later because `Bun` does not exist. The normal Bun behavior and every existing test for runners, watchers, and orchestrators are unchanged. CI uses Node 22.23.2 so this behavior is always checked against the same known version.
+
+The separate Babysit skill now follows the same three-choice rule as poteto-mode Babysit: fix the problem, dismiss it, or ask what to do. Both versions point to one official Bugbot policy. A check of the packaged files confirms that both links work, only one copy of the policy exists, all three choices are present, and the listed situations default to asking, so the two versions cannot quietly become different.
+
 ## 1.1.0 adds selectable requested effort to setup-pstack
 
 `setup-pstack` asks one requested effort per frontier family (`low`, `medium`, `high`, `xhigh`, `max`) instead of probing a fixed default quartet. `provider-dispatch.md` owns the model matrix: family, upstream choice, provider, model, first-run default effort, selectable efforts, and Claude-native agent stem. Setup loads the current sheet first, folds mixed per-family efforts with an explicit operator choice, probes only the four requested pairs, and writes nothing on a failed probe. A rerun rewrites that family's `@effort` suffix on every assigned role and leaves customized role-to-family lanes in place. First-run defaults remain Fable `max`, Sol `max`, Grok `xhigh`, and Opus `xhigh`.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This repository also keeps:
 
 ## Staying close to Lauren's pstack
 
-Open Pstack 1.1.0 tracks pstack 0.14.3 at Cursor commit [`bdf7aa355337897f167153e05069aca505dae17c`](https://github.com/cursor/plugins/commit/bdf7aa355337897f167153e05069aca505dae17c).
+Open Pstack 1.2.0 tracks pstack 0.14.3 at Cursor commit [`bdf7aa355337897f167153e05069aca505dae17c`](https://github.com/cursor/plugins/commit/bdf7aa355337897f167153e05069aca505dae17c).
 
 The two projects have separate version numbers. The pstack version identifies Lauren's upstream content. The Open Pstack version identifies the Claude Code and Codex package built from it.
 

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -10,9 +10,9 @@ open-pstack tracks [Cursor's pstack](https://github.com/cursor/plugins/tree/main
 | Path | `pstack/` |
 | Commit | `bdf7aa355337897f167153e05069aca505dae17c` |
 | Upstream version | `0.14.3` |
-| open-pstack version | `1.1.0` |
+| open-pstack version | `1.2.0` |
 
-The table above is the current Cursor sync point. Open Pstack 1.1.0 shipped against an earlier commit. The next release consolidates this 0.14.3 sync. `README-UPSTREAM.md` preserves its pstack README verbatim. `CHANGES.md` and `NOTICE.md` describe the adaptations and provenance.
+The table above is the current Cursor sync point. Open Pstack 1.2.0 consolidates this 0.14.3 sync. `README-UPSTREAM.md` preserves its pstack README verbatim. `CHANGES.md` and `NOTICE.md` describe the adaptations and provenance.
 
 ## Check for changes
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2,7 +2,7 @@
 
 This page contains the full skill, dependency, runtime, and porting reference. For the plain-English introduction and quick start, see the [main README](../README.md).
 
-[Poteto](https://x.com/poteto)'s [pstack](https://github.com/cursor/plugins/tree/main/pstack), adapted to run in Claude Code and Codex without Cursor. One shared skill tree serves both harnesses; Grok remains available as a model-provider lane. Version 1.1.0 is synced to Cursor pstack v0.14.3 at `bdf7aa355337897f167153e05069aca505dae17c`. See [UPSTREAM.md](../UPSTREAM.md) for the exact sync contract.
+[Poteto](https://x.com/poteto)'s [pstack](https://github.com/cursor/plugins/tree/main/pstack), adapted to run in Claude Code and Codex without Cursor. One shared skill tree serves both harnesses; Grok remains available as a model-provider lane. Version 1.2.0 is synced to Cursor pstack v0.14.3 at `bdf7aa355337897f167153e05069aca505dae17c`. See [UPSTREAM.md](../UPSTREAM.md) for the exact sync contract.
 
 Original by Lauren Tan. This distribution builds on Michael Denyer's [pstack-claude](https://github.com/michael-denyer/pstack-claude) port and retains its history and MIT attribution. It imports seven MIT-licensed skills from [cursor-team-kit](https://github.com/cursor/plugins/tree/main/cursor-team-kit): `deslop`, `thermo-nuclear-code-quality-review`, `make-pr-easy-to-review`, `fix-ci`, `fix-merge-conflicts`, `get-pr-comments`, `what-did-i-get-done`.
 

--- a/plugins/pstack/.claude-plugin/plugin.json
+++ b/plugins/pstack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pstack",
   "displayName": "pstack",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. Ported from cursor/plugins/pstack for Claude Code and Codex.",
   "author": {
     "name": "Lauren Tan"

--- a/plugins/pstack/.codex-plugin/plugin.json
+++ b/plugins/pstack/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pstack",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. Codex port of the Claude Code plugin; skills are shared, tool names resolve via skills/poteto-mode/references/codex-tools.md.",
   "author": {
     "name": "Lauren Tan"


### PR DESCRIPTION
## Summary

- bump Open Pstack from 1.1.0 to 1.2.0 after merging #17, #18, and #20
- update the public version references and both plugin manifests
- add a plain-language changelog entry produced with `pstack:bro`

## Verification

- [x] full test suite: 155 tests, 635 assertions
- [x] TypeScript checking
- [x] Node syntax checks
- [x] Claude and Codex manifest validation
- [x] marketplace validation
- [x] static version and release invariant checks
- [x] no current 1.1.0 references outside historical changelog entries

## Installed-host proof

- [x] every tracked plugin file byte-matches both installed 1.2.0 caches
- [x] installed Claude and Codex checkers each accept the corresponding saved three-PR plan
- [x] installed Claude and Codex startup paths each emit the intended early diagnostic under Node
- [x] fresh Claude and Codex sessions each resolve and invoke installed `pstack:bro`
- [x] neither live canary invokes `pstack:how` or changes the release worktree

## Final review gate

- [x] exact-head source verifier: CLEAN
- [x] exact-head executable-gates verifier: CLEAN
- [x] exact-head installed-host verifier: CLEAN
- [x] independent four-ledger audit: CLEAN, no unresolved Attention

## Release contents

- #17: verified multi-PR implementation plans
- #18: explicit Node runtime diagnostics for Bun-only entry points
- #20: one shared Bugbot triage rubric for both Babysit paths
