### PR TITLE
fix(runner): Grok read-only lanes bypass the permission classifier, and failures name their state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 This port applies the Cursor → Claude Code substitutions in skill bodies. Earlier drafts left them flagged; this revision resolves them. A later pass added a Codex build that shares the same skills; see [Codex port](#codex-port) below.
 
+## Unreleased bypasses the permission classifier for read-only Grok lanes and names Grok terminal errors
+
+Read-only Grok lanes now pass `--permission-mode bypassPermissions`. Grok treats `plan` as a no-op and falls back to the host default. Under `auto`, an uncleared command escalates to an interactive prompt no headless lane can answer, and the 30 s timeout kills the lane. The read-only seatbelt sandbox forbids writes and has no network, so bypassing the classifier there has no write-side risk. Isolated-write Grok lanes still use `acceptEdits` and the workspace sandbox.
+
+A non-success Grok terminal event now names `subtype` and `stop_reason` in the error instead of the flat `grok reported an error result`.
+
 ## 1.2.0 adds verified multi-PR plans, earlier runtime diagnostics, and shared review-bot triage
 
 Plans with several stages now use one checklist instead of an overview and separate files for each stage. It has one ordered section for every pull request and keeps all ten ways of testing the real product, unit tests, live and performance proof, checks for how changes work together, merge rules, and supporting details in one place. A Node-based checker with no extra dependencies rejects missing or out-of-order sections, fake screenshots, empty definitions of success, incomplete performance proof, incorrectly written review checks, unsupported punctuation, and incorrect command use. Claude Code and Codex use the same installed skill and checker through their existing parent-controlled setup. If a provider fails, it is identified by name and treated as a dropout. No backup provider or hidden time limit was added.

--- a/plugins/pstack/skills/poteto-mode/scripts/runner/commands.test.ts
+++ b/plugins/pstack/skills/poteto-mode/scripts/runner/commands.test.ts
@@ -96,7 +96,7 @@ describe("invocationCommand", () => {
       "--reasoning-effort",
       "xhigh",
       "--permission-mode",
-      "plan",
+      "bypassPermissions",
       "--sandbox",
       "read-only",
       "--tools",
@@ -111,6 +111,25 @@ describe("invocationCommand", () => {
       "--disable-web-search",
       "--verbatim",
     ]);
+  });
+
+  it("keeps acceptEdits and the workspace sandbox for isolated-write Grok lanes", () => {
+    const spec = invocationCommand(
+      options({
+        provider: "grok",
+        model: "grok-4.6",
+        effort: "xhigh",
+        mode: "isolated-write",
+      })
+    );
+    expect(spec.args).toEqual(
+      expect.arrayContaining([
+        "--permission-mode",
+        "acceptEdits",
+        "--sandbox",
+        "workspace",
+      ])
+    );
   });
 
   it("uses bounded write modes without blanket bypasses", () => {

--- a/plugins/pstack/skills/poteto-mode/scripts/runner/commands.ts
+++ b/plugins/pstack/skills/poteto-mode/scripts/runner/commands.ts
@@ -55,6 +55,18 @@ function grokTools(mode: AccessMode): string {
   return [...readonly, ...(mode === "isolated-write" ? ["search_replace"] : [])].join(",");
 }
 
+// grok treats plan/dontAsk as compatibility no-ops and falls back to the
+// host's .claude/settings.json defaultMode; under auto, uncleared commands
+// escalate to an interactive prompt no headless lane can answer, and the
+// 30s timeout kills the lane (measured 2026-08-29). Founder-approved scope,
+// same date: bypassPermissions ONLY for read-only grok lanes, where the
+// seatbelt sandbox forbids writes and no network exists, so the classifier's
+// only headless effect was killing reviewers mid-run. Write lanes keep the
+// classifier: test-gaming inside a workspace-write sandbox is a real threat.
+function grokPermissionMode(mode: AccessMode): string {
+  return mode === "read-only" ? "bypassPermissions" : permissionMode(mode);
+}
+
 function permissionMode(mode: AccessMode): string {
   return mode === "read-only" ? "plan" : "acceptEdits";
 }
@@ -129,7 +141,7 @@ export function invocationCommand(options: RunnerOptions): CommandSpec {
           "--reasoning-effort",
           options.effort,
           "--permission-mode",
-          permissionMode(options.mode),
+          grokPermissionMode(options.mode),
           "--sandbox",
           grokSandbox(options.mode),
           "--tools",

--- a/plugins/pstack/skills/poteto-mode/scripts/runner/parse-output.test.ts
+++ b/plugins/pstack/skills/poteto-mode/scripts/runner/parse-output.test.ts
@@ -123,4 +123,34 @@ describe("parseProviderOutput", () => {
       )
     ).toThrow("final agent message");
   });
+
+  it("names Grok's terminal state on a non-success result", () => {
+    expect(() =>
+      parseProviderOutput(
+        "grok",
+        JSON.stringify({
+          type: "result",
+          subtype: "error",
+          is_error: true,
+          stop_reason: "permission_timeout",
+        }),
+        "",
+        "grok-4.6"
+      )
+    ).toThrow("subtype=error, stop_reason=permission_timeout");
+  });
+
+  it("names an absent Grok subtype on a non-success result", () => {
+    expect(() =>
+      parseProviderOutput(
+        "grok",
+        JSON.stringify({
+          type: "result",
+          is_error: true,
+        }),
+        "",
+        "grok-4.6"
+      )
+    ).toThrow("subtype=absent");
+  });
 });

--- a/plugins/pstack/skills/poteto-mode/scripts/runner/parse-output.ts
+++ b/plugins/pstack/skills/poteto-mode/scripts/runner/parse-output.ts
@@ -90,7 +90,12 @@ function parseGrok(stdout: string, requestedModel: string): ParsedOutput {
 
   if (result === null) throw new Error("grok result did not contain a terminal event");
   if (result.is_error === true || result.subtype !== "success") {
-    throw new Error("grok reported an error result");
+    // Name the terminal state: without subtype/stop_reason a permission
+    // timeout, a refusal and a crash all read the same in the receipt.
+    const subtype = nullableString(result.subtype) ?? "absent";
+    const stopReason = nullableString(result.stop_reason);
+    const detail = stopReason === null ? "" : `, stop_reason=${stopReason}`;
+    throw new Error(`grok reported a non-success result (subtype=${subtype}${detail})`);
   }
   const text = nullableString(result.result);
   if (text === null) throw new Error("grok result did not contain final text");


### PR DESCRIPTION
## Why

Two runner fixes have lived only as uncommitted edits in one machine's installed copy of this plugin since 2026-08-29. A plugin update would erase them. This PR carries them upstream with tests so they survive.

## Scope

- `runner/commands.ts`: `grokPermissionMode` returns `bypassPermissions` for read-only Grok lanes and keeps `acceptEdits` for isolated-write lanes. Grok treats `plan` as a no-op and falls back to the host's default permission mode; under `auto`, an uncleared command escalates to an interactive prompt that no headless lane can answer, and the 30 s timeout kills the lane. The read-only seatbelt sandbox forbids writes and has no network, so bypassing the classifier there has no write-side risk. Write lanes keep the classifier.
- `runner/parse-output.ts`: a Grok terminal event that is not a success now raises `grok reported a non-success result (subtype=…, stop_reason=…)` instead of a flat error, so a permission timeout, a refusal, and a crash read differently in the receipt.
- Tests updated and added in `commands.test.ts` and `parse-output.test.ts`; `CHANGES.md` notes both.

## Blast Radius

Only Grok lanes launched by `pstack-runner`. Read-only Grok lanes stop dying at the permission classifier; write lanes are unchanged. Error text for failed Grok lanes changes; nothing parses that text.

## Verification

`bun run test` in `plugins/pstack/skills/poteto-mode/scripts`: 158 pass, 0 fail (baseline 155). `bun run typecheck`: exit 0. The read-only bypass was measured on 2026-08-29 on the reporting machine, where write lanes under `auto` were being killed by the permission prompt timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)